### PR TITLE
Fixes to idletiming.Conn to make sure it closes after idling

### DIFF
--- a/src/github.com/getlantern/connpool/connpool_test.go
+++ b/src/github.com/getlantern/connpool/connpool_test.go
@@ -1,17 +1,15 @@
 package connpool
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"net"
-	"os"
-	"os/exec"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/getlantern/fdcount"
 	"github.com/getlantern/testify/assert"
 	"github.com/getlantern/waitforserver"
 )
@@ -37,7 +35,10 @@ func TestIt(t *testing.T) {
 		},
 	}
 
-	fdCountStart := countTCPFiles()
+	_, fdc, err := fdcount.Matching("TCP")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	p.Start()
 	// Run another Start() concurrently just to make sure it doesn't muck things up
@@ -45,15 +46,13 @@ func TestIt(t *testing.T) {
 
 	time.Sleep(fillTime)
 
-	openConns := countTCPFiles() - fdCountStart
-	assert.Equal(t, poolSize, openConns, "Pool should initially open the right number of conns")
+	assert.NoError(t, fdc.AssertDelta(poolSize), "Pool should initially open the right number of conns")
 
 	// Use more than the pooled connections
 	connectAndRead(t, p, poolSize*2)
 
 	time.Sleep(fillTime)
-	openConns = countTCPFiles() - fdCountStart
-	assert.Equal(t, poolSize, openConns, "Pool should fill itself back up to the right number of conns")
+	assert.NoError(t, fdc.AssertDelta(poolSize), "Pool should fill itself back up to the right number of conns")
 
 	// Wait for connections to time out
 	time.Sleep(claimTimeout * 2)
@@ -62,8 +61,7 @@ func TestIt(t *testing.T) {
 	connectAndRead(t, p, poolSize*2)
 
 	time.Sleep(fillTime)
-	openConns = countTCPFiles() - fdCountStart
-	assert.Equal(t, poolSize, openConns, "After pooled conns time out, pool should fill itself back up to the right number of conns")
+	assert.NoError(t, fdc.AssertDelta(poolSize), "After pooled conns time out, pool should fill itself back up to the right number of conns")
 
 	// Make a dial function that randomly returns closed connections
 	p.Dial = func() (net.Conn, error) {
@@ -85,8 +83,7 @@ func TestIt(t *testing.T) {
 	// Run another Stop() concurrently just to make sure it doesn't muck things up
 	go p.Stop()
 
-	openConns = countTCPFiles() - fdCountStart
-	assert.Equal(t, 0, openConns, "After stopping pool, there should be no more open conns")
+	assert.NoError(t, fdc.AssertDelta(0), "After stopping pool, there should be no more open conns")
 }
 
 func TestDialFailure(t *testing.T) {
@@ -166,13 +163,4 @@ func startTestServer() (string, error) {
 		}
 	}()
 	return l.Addr().String(), nil
-}
-
-// see https://groups.google.com/forum/#!topic/golang-nuts/c0AnWXjzNIA
-func countTCPFiles() int {
-	out, err := exec.Command("lsof", "-p", fmt.Sprintf("%v", os.Getpid())).Output()
-	if err != nil {
-		log.Fatal(err)
-	}
-	return bytes.Count(out, []byte("TCP")) - 1
 }

--- a/src/github.com/getlantern/enproxy/lazyconn.go
+++ b/src/github.com/getlantern/enproxy/lazyconn.go
@@ -49,6 +49,7 @@ func (l *lazyConn) get() (conn net.Conn, err error) {
 			l.p.connMapMutex.Lock()
 			defer l.p.connMapMutex.Unlock()
 			delete(l.p.connMap, l.id)
+			conn.Close()
 		})
 	}
 

--- a/src/github.com/getlantern/fdcount/.travis.yml
+++ b/src/github.com/getlantern/fdcount/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+
+go:
+  - 1.4
+
+install:
+  - go get -d -t -v ./...
+  - go build -v ./...
+  - go get golang.org/x/tools/cmd/cover
+  - go get -v github.com/axw/gocov/gocov
+  - go get -v github.com/mattn/goveralls
+
+script:
+  - $HOME/gopath/bin/goveralls -v -service travis-ci github.com/getlantern/fdcount

--- a/src/github.com/getlantern/fdcount/README.md
+++ b/src/github.com/getlantern/fdcount/README.md
@@ -1,0 +1,4 @@
+fdcount [![Travis CI Status](https://travis-ci.org/getlantern/fdcount.svg?branch=master)](https://travis-ci.org/getlantern/fdcount)&nbsp;[![Coverage Status](https://coveralls.io/repos/getlantern/fdcount/badge.png)](https://coveralls.io/r/getlantern/fdcount)&nbsp;[![GoDoc](https://godoc.org/github.com/getlantern/fdcount?status.png)](http://godoc.org/github.com/getlantern/fdcount)
+==========
+package fdcount contains provides utility functions for counting file
+descriptors used by the current process.

--- a/src/github.com/getlantern/fdcount/fdcount.go
+++ b/src/github.com/getlantern/fdcount/fdcount.go
@@ -1,0 +1,62 @@
+package fdcount
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+type Counter struct {
+	match         string
+	startingCount int
+	startingOut   []byte
+}
+
+// Returns a count of the file descriptors matching the given string (not a
+// regex). Also returns a Counter that can be used to check the delta of file
+// descriptors after this point.
+//
+// Currently only works on systems that have the lsof command available.
+//
+// see https://groups.google.com/forum/#!topic/golang-nuts/c0AnWXjzNIA
+//
+func Matching(s string) (int, *Counter, error) {
+	c := &Counter{match: s}
+
+	// Count initial file descriptors
+	out, err := runLsof()
+	if err != nil {
+		return 0, nil, err
+	}
+	c.startingOut = out
+	c.startingCount = c.countMatches(out)
+	return c.startingCount, c, nil
+}
+
+// Asserts that the number of file descriptors added/removed since Counter was
+// created euqlas the given number.
+func (c *Counter) AssertDelta(expected int) error {
+	out, err := runLsof()
+	if err != nil {
+		return err
+	}
+	actual := c.countMatches(out) - c.startingCount
+	if actual != expected {
+		return fmt.Errorf("Unexpected TCP file descriptor count. Expected %d, have %d.\n\nInitial lsof output\n-----------------------------\n%s\n\nCurrent lsof output\n-----------------------------\n%s\n",
+			expected, actual, string(c.startingOut), string(out))
+	}
+	return nil
+}
+
+func (c *Counter) countMatches(out []byte) int {
+	return bytes.Count(out, []byte(c.match))
+}
+
+func runLsof() ([]byte, error) {
+	out, err := exec.Command("lsof", "-p", fmt.Sprintf("%v", os.Getpid())).Output()
+	if err != nil {
+		err = fmt.Errorf("Unable to run lsof: %v", err)
+	}
+	return out, err
+}

--- a/src/github.com/getlantern/fdcount/fdcount_test.go
+++ b/src/github.com/getlantern/fdcount/fdcount_test.go
@@ -1,0 +1,42 @@
+package fdcount
+
+import (
+	"net"
+	"testing"
+
+	"github.com/getlantern/testify/assert"
+)
+
+func TestTCP(t *testing.T) {
+	l0, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l0.Close()
+
+	start, fdc, err := Matching("TCP")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 1, start, "Starting count should have been 1")
+
+	err = fdc.AssertDelta(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NoError(t, err, "Initial TCP count should be 0")
+
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	err = fdc.AssertDelta(0)
+	if assert.Error(t, err, "Asserting wrong count should fail") {
+		assert.Contains(t, err.Error(), "Expected 0, have 1")
+		assert.True(t, len(err.Error()) > 100)
+	}
+	err = fdc.AssertDelta(1)
+	assert.NoError(t, err, "Ending TCP count should be 1")
+}

--- a/src/github.com/getlantern/fronted/server.go
+++ b/src/github.com/getlantern/fronted/server.go
@@ -91,7 +91,12 @@ func (server *Server) Listen() (net.Listener, error) {
 
 	// We use an idle timing listener to time out idle HTTP connections, since
 	// the CDNs seem to like keeping lots of connections open indefinitely.
-	return idletiming.Listener(listener, httpIdleTimeout, nil), nil
+	return idletiming.Listener(listener, httpIdleTimeout, func(conn net.Conn) {
+		err := conn.Close()
+		if err != nil {
+			log.Debugf("Unable to close connection: %v", err)
+		}
+	}), nil
 }
 
 func (server *Server) listen() (net.Listener, error) {

--- a/src/github.com/getlantern/idletiming/idletiming_conn.go
+++ b/src/github.com/getlantern/idletiming/idletiming_conn.go
@@ -51,7 +51,6 @@ func Conn(conn net.Conn, idleTimeout time.Duration, onClose func()) *IdleTimingC
 			case <-timer.C:
 				return
 			case <-c.closedCh:
-				c.Close()
 				return
 			}
 		}
@@ -160,7 +159,7 @@ func (c *IdleTimingConn) Write(b []byte) (int, error) {
 }
 
 // Close this IdleTimingConn. This will close the underlying net.Conn as well,
-// however any error from closing that connection is NOT returned here.
+// returning the error from calling its Close method.
 func (c *IdleTimingConn) Close() error {
 	select {
 	case c.closedCh <- true:

--- a/src/github.com/getlantern/idletiming/idletiming_conn.go
+++ b/src/github.com/getlantern/idletiming/idletiming_conn.go
@@ -22,8 +22,8 @@ var (
 // onClose is an optional function to call after the connection has idled or
 // been closed.
 //
-// Note - idletiming.Conn does not close the underlying connection, it is up to
-// clients to handle this in their onClose callback.
+// Note - idletiming.Conn does not close the underlying connection if it idled,
+// it is up to clients to handle this in their onClose callback.
 func Conn(conn net.Conn, idleTimeout time.Duration, onClose func()) *IdleTimingConn {
 	c := &IdleTimingConn{
 		conn:             conn,

--- a/src/github.com/getlantern/idletiming/idletiming_example_test.go
+++ b/src/github.com/getlantern/idletiming/idletiming_example_test.go
@@ -25,7 +25,7 @@ func ExampleListener() {
 		log.Fatalf("Unable to listen %s", err)
 	}
 
-	il := Listener(l, 5*time.Second, func() {
+	il := Listener(l, 5*time.Second, func(conn net.Conn) {
 		log.Printf("Connection was idled")
 	})
 

--- a/src/github.com/getlantern/idletiming/idletiming_listener.go
+++ b/src/github.com/getlantern/idletiming/idletiming_listener.go
@@ -31,9 +31,13 @@ type idleTimingListener struct {
 func (l *idleTimingListener) Accept() (c net.Conn, err error) {
 	c, err = l.orig.Accept()
 	if err == nil {
-		c = Conn(c, l.idleTimeout, func() {
-			l.onClose(c)
-		})
+		var closeFn func()
+		if l.onClose != nil {
+			closeFn = func() {
+				l.onClose(c)
+			}
+		}
+		c = Conn(c, l.idleTimeout, closeFn)
 	}
 	return
 }

--- a/src/github.com/getlantern/idletiming/idletiming_listener.go
+++ b/src/github.com/getlantern/idletiming/idletiming_listener.go
@@ -13,31 +13,29 @@ import (
 // connection idle.  Note - the actual timeout may be up to twice idleTimeout,
 // depending on timing.
 //
-// onClose is an optional function to call after the connection has been closed,
-// whether or not that was due to the connection idling.
-//
-// Note - idletiming.Listener does not close the underlying connections upon
-// timing out, it is up to clients to handle this in their onClose callback.
-func Listener(listener net.Listener, idleTimeout time.Duration, onClose func(conn net.Conn)) net.Listener {
-	return &idleTimingListener{listener, idleTimeout, onClose}
+// onIdle is a required function that's called if a connection idles.
+// idletiming.Conn does not close the underlying connection on idle, you have to
+// do that in your onIdle callback.
+func Listener(listener net.Listener, idleTimeout time.Duration, onIdle func(conn net.Conn)) net.Listener {
+	if onIdle == nil {
+		panic("onIdle is required")
+	}
+
+	return &idleTimingListener{listener, idleTimeout, onIdle}
 }
 
 type idleTimingListener struct {
 	orig        net.Listener
 	idleTimeout time.Duration
-	onClose     func(conn net.Conn)
+	onIdle      func(conn net.Conn)
 }
 
 func (l *idleTimingListener) Accept() (c net.Conn, err error) {
 	c, err = l.orig.Accept()
 	if err == nil {
-		var closeFn func()
-		if l.onClose != nil {
-			closeFn = func() {
-				l.onClose(c)
-			}
-		}
-		c = Conn(c, l.idleTimeout, closeFn)
+		c = Conn(c, l.idleTimeout, func() {
+			l.onIdle(c)
+		})
 	}
 	return
 }

--- a/src/github.com/getlantern/idletiming/idletiming_test.go
+++ b/src/github.com/getlantern/idletiming/idletiming_test.go
@@ -228,9 +228,17 @@ func TestClose(t *testing.T) {
 		t.Fatalf("Unable to dial %s: %s", addr, err)
 	}
 
-	c := Conn(conn, clientTimeout, nil)
+	closeCallbackCalled := int32(0)
+	c := Conn(conn, clientTimeout, func() {
+		atomic.StoreInt32(&closeCallbackCalled, 1)
+	})
 	for i := 0; i < 100; i++ {
 		c.Close()
+	}
+
+	time.Sleep(1 * time.Second)
+	if closeCallbackCalled == 0 {
+		t.Errorf("Close callback was not called")
 	}
 }
 

--- a/src/github.com/getlantern/idletiming/idletiming_test.go
+++ b/src/github.com/getlantern/idletiming/idletiming_test.go
@@ -228,17 +228,9 @@ func TestClose(t *testing.T) {
 		t.Fatalf("Unable to dial %s: %s", addr, err)
 	}
 
-	closeCallbackCalled := int32(0)
-	c := Conn(conn, clientTimeout, func() {
-		atomic.StoreInt32(&closeCallbackCalled, 1)
-	})
+	c := Conn(conn, clientTimeout, func() {})
 	for i := 0; i < 100; i++ {
 		c.Close()
-	}
-
-	time.Sleep(1 * time.Second)
-	if closeCallbackCalled == 0 {
-		t.Errorf("Close callback was not called")
 	}
 }
 

--- a/testpackages.txt
+++ b/testpackages.txt
@@ -6,6 +6,7 @@ github.com/getlantern/chained
 github.com/getlantern/connpool
 github.com/getlantern/deepcopy
 github.com/getlantern/enproxy
+github.com/getlantern/fdcount
 github.com/getlantern/framed
 github.com/getlantern/fronted
 github.com/getlantern/golog


### PR DESCRIPTION
This will prevent leaking file descriptors on the flashlight server.