### PR TITLE
Adding build tags to disable runServerProxy on android.

### DIFF
--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -12,12 +12,10 @@ import (
 	"runtime/pprof"
 	"time"
 
-	"github.com/getlantern/fronted"
 	"github.com/getlantern/golog"
 
 	"github.com/getlantern/flashlight/client"
 	"github.com/getlantern/flashlight/config"
-	"github.com/getlantern/flashlight/server"
 	"github.com/getlantern/flashlight/statreporter"
 	"github.com/getlantern/flashlight/statserver"
 )
@@ -133,38 +131,6 @@ func runClientProxy(cfg *config.Config) {
 	err := client.ListenAndServe()
 	if err != nil {
 		log.Fatalf("Unable to run client proxy: %s", err)
-	}
-}
-
-// Runs the server-side proxy
-func runServerProxy(cfg *config.Config) {
-	useAllCores()
-
-	srv := &server.Server{
-		Addr:         cfg.Addr,
-		Host:         cfg.Server.AdvertisedHost,
-		ReadTimeout:  0, // don't timeout
-		WriteTimeout: 0,
-		CertContext: &fronted.CertContext{
-			PKFile:         config.InConfigDir("proxypk.pem"),
-			ServerCertFile: config.InConfigDir("servercert.pem"),
-		},
-	}
-
-	srv.Configure(cfg.Server)
-
-	// Continually poll for config updates and update server accordingly
-	go func() {
-		for {
-			cfg := <-configUpdates
-			configureStats(cfg, false)
-			srv.Configure(cfg.Server)
-		}
-	}()
-
-	err := srv.ListenAndServe()
-	if err != nil {
-		log.Fatalf("Unable to run server proxy: %s", err)
 	}
 }
 

--- a/src/github.com/getlantern/flashlight/server.go
+++ b/src/github.com/getlantern/flashlight/server.go
@@ -1,0 +1,41 @@
+// +build darwin dragonfly freebsd !android,linux netbsd openbsd solaris
+
+package main
+
+import (
+	"github.com/getlantern/flashlight/config"
+	"github.com/getlantern/flashlight/server"
+	"github.com/getlantern/fronted"
+)
+
+// Runs the server-side proxy
+func runServerProxy(cfg *config.Config) {
+	useAllCores()
+
+	srv := &server.Server{
+		Addr:         cfg.Addr,
+		Host:         cfg.Server.AdvertisedHost,
+		ReadTimeout:  0, // don't timeout
+		WriteTimeout: 0,
+		CertContext: &fronted.CertContext{
+			PKFile:         config.InConfigDir("proxypk.pem"),
+			ServerCertFile: config.InConfigDir("servercert.pem"),
+		},
+	}
+
+	srv.Configure(cfg.Server)
+
+	// Continually poll for config updates and update server accordingly
+	go func() {
+		for {
+			cfg := <-configUpdates
+			configureStats(cfg, false)
+			srv.Configure(cfg.Server)
+		}
+	}()
+
+	err := srv.ListenAndServe()
+	if err != nil {
+		log.Fatalf("Unable to run server proxy: %s", err)
+	}
+}

--- a/src/github.com/getlantern/flashlight/server_stubs.go
+++ b/src/github.com/getlantern/flashlight/server_stubs.go
@@ -1,0 +1,14 @@
+// +build android
+
+package main
+
+import (
+	"runtime"
+
+	"github.com/getlantern/flashlight/config"
+)
+
+// runServerProxy is not implemented.
+func runServerProxy(cfg *config.Config) {
+	log.Debugf("runServerProxy not implemented in %s/%s.", runtime.GOOS, runtime.GOARCH)
+}

--- a/src/github.com/getlantern/go-natty/natty/bin/natty_stubs.go
+++ b/src/github.com/getlantern/go-natty/natty/bin/natty_stubs.go
@@ -1,0 +1,25 @@
+// +build android
+
+package bin
+
+import (
+	"errors"
+)
+
+var (
+	errNotImplemented = errors.New(`Not implemented.`)
+)
+
+// Asset is not implemented.
+func Asset(name string) ([]byte, error) {
+	return nil, errNotImplemented
+}
+
+// AssetNames is not implemented.
+func AssetNames() []string {
+	return nil
+}
+
+func AssetDir(name string) ([]string, error) {
+	return nil, errNotImplemented
+}


### PR DESCRIPTION
This commit adds build tags to disable `runServerProxy()` on Android, since server features are not supported on that kind of architecture.

See discussion at: https://github.com/getlantern/lantern/issues/2142#issuecomment-69120399
