### PR TITLE
Enproxy intf cleanup

### DIFF
--- a/src/github.com/getlantern/balancer/.travis.yml
+++ b/src/github.com/getlantern/balancer/.travis.yml
@@ -6,7 +6,7 @@ go:
 install:
   - go get -d -t -v ./...
   - go build -v ./...
-  - go get code.google.com/p/go.tools/cmd/cover
+  - go get golang.org/x/tools/cmd/cover
   - go get -v github.com/axw/gocov/gocov
   - go get -v github.com/mattn/goveralls
 

--- a/src/github.com/getlantern/bytecounting/.travis.yml
+++ b/src/github.com/getlantern/bytecounting/.travis.yml
@@ -6,7 +6,7 @@ go:
 install:
   - go get -d -t -v ./...
   - go build -v ./...
-  - go get code.google.com/p/go.tools/cmd/cover
+  - go get golang.org/x/tools/cmd/cover
   - go get -v github.com/axw/gocov/gocov
   - go get -v github.com/mattn/goveralls
 

--- a/src/github.com/getlantern/chained/.travis.yml
+++ b/src/github.com/getlantern/chained/.travis.yml
@@ -6,7 +6,7 @@ go:
 install:
   - go get -d -t -v ./...
   - go build -v ./...
-  - go get code.google.com/p/go.tools/cmd/cover
+  - go get golang.org/x/tools/cmd/cover
   - go get -v github.com/axw/gocov/gocov
   - go get -v github.com/mattn/goveralls
 

--- a/src/github.com/getlantern/enproxy/conn_http.go
+++ b/src/github.com/getlantern/enproxy/conn_http.go
@@ -21,17 +21,19 @@ func (c *Config) Intercept(resp http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		resp.WriteHeader(502)
 		fmt.Fprintf(resp, "Unable to hijack connection: %s", err)
+		return
 	}
 	defer clientConn.Close()
 
 	addr := hostIncludingPort(req, 443)
 
 	// Establish outbound connection
-	connOut := &Conn{
-		Addr:   addr,
-		Config: c,
+	connOut, err := Dial(addr, c)
+	if err != nil {
+		resp.WriteHeader(502)
+		fmt.Fprintf(resp, "Unable to open enproxy connection: %s", err)
+		return
 	}
-	connOut.Connect()
 	defer connOut.Close()
 
 	// Pipe data

--- a/src/github.com/getlantern/enproxy/conn_impl_reads.go
+++ b/src/github.com/getlantern/enproxy/conn_impl_reads.go
@@ -33,7 +33,7 @@ func (c *Conn) processReads() {
 	}()
 
 	mkerror := func(text string, err error) error {
-		return fmt.Errorf("Dest: %s    ProxyHost: %s    %s: %s", c.Addr, proxyHost, text, err)
+		return fmt.Errorf("Dest: %s    ProxyHost: %s    %s: %s", c.addr, proxyHost, text, err)
 	}
 
 	for {
@@ -97,7 +97,7 @@ func (c *Conn) processReads() {
 			}
 		case <-c.stopReadCh:
 			return
-		case <-time.After(c.Config.IdleTimeout):
+		case <-time.After(c.config.IdleTimeout):
 			if c.isIdle() {
 				return
 			}

--- a/src/github.com/getlantern/enproxy/conn_impl_requests.go
+++ b/src/github.com/getlantern/enproxy/conn_impl_requests.go
@@ -30,7 +30,7 @@ func (c *Conn) processRequests(proxyConn *connInfo) {
 	var proxyHost string
 
 	mkerror := func(text string, err error) error {
-		return fmt.Errorf("Dest: %s    ProxyHost: %s    %s: %s", c.Addr, proxyHost, text, err)
+		return fmt.Errorf("Dest: %s    ProxyHost: %s    %s: %s", c.addr, proxyHost, text, err)
 	}
 
 	for {
@@ -91,7 +91,7 @@ func (c *Conn) processRequests(proxyConn *connInfo) {
 			}
 		case <-c.stopRequestCh:
 			return
-		case <-time.After(c.Config.IdleTimeout):
+		case <-time.After(c.config.IdleTimeout):
 			if c.isIdle() {
 				return
 			}

--- a/src/github.com/getlantern/enproxy/conn_impl_writes.go
+++ b/src/github.com/getlantern/enproxy/conn_impl_writes.go
@@ -37,7 +37,7 @@ func (c *Conn) processWrites() {
 			}
 		case <-c.stopWriteCh:
 			return
-		case <-time.After(c.Config.FlushTimeout):
+		case <-time.After(c.config.FlushTimeout):
 			// We waited more than FlushTimeout for a write, finish our request
 
 			if c.isIdle() {

--- a/src/github.com/getlantern/enproxy/conn_intf.go
+++ b/src/github.com/getlantern/enproxy/conn_intf.go
@@ -78,11 +78,11 @@ var (
 //      from the destination server, return EOF to the reader
 //
 type Conn struct {
-	// Addr: the host:port of the destination server that we're trying to reach
-	Addr string
+	// addr: the host:port of the destination server that we're trying to reach
+	addr string
 
-	// Config: configuration of this Conn
-	Config *Config
+	// config: configuration of this Conn
+	config *Config
 
 	// initialResponseCh: Self-reported FQDN of the proxy serving this connection
 	// plus initial response from proxy.

--- a/src/github.com/getlantern/enproxy/conn_test.go
+++ b/src/github.com/getlantern/enproxy/conn_test.go
@@ -115,9 +115,8 @@ func doTestBad(buffered bool, t *testing.T) {
 }
 
 func prepareConn(addr string, buffered bool, fail bool, t *testing.T) (conn *Conn, err error) {
-	conn = &Conn{
-		Addr: addr,
-		Config: &Config{
+	return Dial(addr,
+		&Config{
 			DialProxy: func(addr string) (net.Conn, error) {
 				proto := "tcp"
 				if fail {
@@ -132,10 +131,7 @@ func prepareConn(addr string, buffered bool, fail bool, t *testing.T) (conn *Con
 				return http.NewRequest(method, "http://"+host, body)
 			},
 			BufferRequests: buffered,
-		},
-	}
-	err = conn.Connect()
-	return
+		})
 }
 
 func doRequests(conn net.Conn, t *testing.T) {

--- a/src/github.com/getlantern/enproxy/test/client/client.go
+++ b/src/github.com/getlantern/enproxy/test/client/client.go
@@ -34,12 +34,7 @@ func main() {
 				},
 				Transport: &http.Transport{
 					Dial: func(network string, addr string) (net.Conn, error) {
-						conn := &enproxy.Conn{
-							Addr:   addr,
-							Config: enproxyConfig,
-						}
-						conn.Connect()
-						return conn, nil
+						return enproxy.Dial(addr, enproxyConfig)
 					},
 				},
 			},

--- a/src/github.com/getlantern/fronted/.travis.yml
+++ b/src/github.com/getlantern/fronted/.travis.yml
@@ -6,7 +6,7 @@ go:
 install:
   - go get -d -t -v ./...
   - go build -v ./...
-  - go get code.google.com/p/go.tools/cmd/cover
+  - go get golang.org/x/tools/cmd/cover
   - go get -v github.com/axw/gocov/gocov
   - go get -v github.com/mattn/goveralls
 

--- a/src/github.com/getlantern/fronted/dialer.go
+++ b/src/github.com/getlantern/fronted/dialer.go
@@ -125,15 +125,7 @@ func (d *Dialer) Dial(network, addr string) (net.Conn, error) {
 		return nil, fmt.Errorf("Protocol %s is not supported, only tcp is supported", network)
 	}
 
-	conn := &enproxy.Conn{
-		Addr:   addr,
-		Config: d.enproxyConfig,
-	}
-	err := conn.Connect()
-	if err != nil {
-		return nil, err
-	}
-	return conn, nil
+	return enproxy.Dial(addr, d.enproxyConfig)
 }
 
 // Close closes the dialer, in particular closing the underlying connection
@@ -159,15 +151,7 @@ func (d *Dialer) HttpClientUsing(masquerade *Masquerade) *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
 			Dial: func(network, addr string) (net.Conn, error) {
-				conn := &enproxy.Conn{
-					Addr:   addr,
-					Config: enproxyConfig,
-				}
-				err := conn.Connect()
-				if err != nil {
-					return nil, err
-				}
-				return conn, nil
+				return enproxy.Dial(addr, enproxyConfig)
 			},
 		},
 	}


### PR DESCRIPTION
While prepping my presentation for Thursday, I realized that the API for opening an enproxy.Conn isn't very standard.  I've updated it to look more like a normal net.Conn, namely using a Dial function.
