### PR TITLE
Issue 2185

### DIFF
--- a/src/github.com/getlantern/connpool/connpool.go
+++ b/src/github.com/getlantern/connpool/connpool.go
@@ -128,12 +128,15 @@ func (p *Pool) Get() (net.Conn, error) {
 }
 
 func (p *Pool) freshen() {
+	log.Trace("Freshen requested")
+
+	freshened := 0
 	for {
 		select {
 		case p.freshenCh <- nil:
-			log.Trace("Freshened one connection")
+			freshened += 1
 		default:
-			log.Trace("No more to freshen")
+			log.Tracef("No more to freshen, freshened %d connections", freshened)
 			return
 		}
 	}

--- a/src/github.com/getlantern/connpool/connpool_test.go
+++ b/src/github.com/getlantern/connpool/connpool_test.go
@@ -28,7 +28,7 @@ func TestIt(t *testing.T) {
 		t.Fatalf("Unable to start test server: %s", err)
 	}
 	p := &Pool{
-		MinSize:      poolSize,
+		Size:         poolSize,
 		ClaimTimeout: claimTimeout,
 		Dial: func() (net.Conn, error) {
 			return net.DialTimeout("tcp", addr, 15*time.Millisecond)
@@ -46,7 +46,7 @@ func TestIt(t *testing.T) {
 
 	time.Sleep(fillTime)
 
-	assert.NoError(t, fdc.AssertDelta(poolSize), "Pool should initially open the right number of conns")
+	assert.NoError(t, fdc.AssertDelta(0), "Pool should initially contain no conns")
 
 	// Use more than the pooled connections
 	connectAndRead(t, p, poolSize*2)
@@ -56,6 +56,8 @@ func TestIt(t *testing.T) {
 
 	// Wait for connections to time out
 	time.Sleep(claimTimeout * 2)
+
+	assert.NoError(t, fdc.AssertDelta(0), "After connections time out, but before dialing again, pool should be empty")
 
 	// Test our connections again
 	connectAndRead(t, p, poolSize*2)
@@ -95,7 +97,7 @@ func TestDialFailure(t *testing.T) {
 		t.Fatalf("Unable to start test server: %s", err)
 	}
 	p := &Pool{
-		MinSize:              10,
+		Size:                 10,
 		RedialDelayIncrement: 10 * time.Millisecond,
 		MaxRedialDelay:       100 * time.Millisecond,
 		Dial: func() (net.Conn, error) {

--- a/src/github.com/getlantern/flashlight/client/fronted.go
+++ b/src/github.com/getlantern/flashlight/client/fronted.go
@@ -53,7 +53,7 @@ func (s *FrontedServerInfo) dialer(masqueradeSets map[string][]*fronted.Masquera
 	fd := fronted.NewDialer(&fronted.Config{
 		Host:               s.Host,
 		Port:               s.Port,
-		PoolSize:           0,
+		PoolSize:           30,
 		InsecureSkipVerify: s.InsecureSkipVerify,
 		BufferRequests:     s.BufferRequests,
 		DialTimeoutMillis:  s.DialTimeoutMillis,

--- a/src/github.com/getlantern/fronted/dialer.go
+++ b/src/github.com/getlantern/fronted/dialer.go
@@ -114,10 +114,11 @@ func NewDialer(cfg *Config) *Dialer {
 	}
 	if cfg.PoolSize > 0 {
 		d.connPool = &connpool.Pool{
-			MinSize:      cfg.PoolSize,
+			Size:         cfg.PoolSize,
 			ClaimTimeout: idleTimeout,
 			Dial:         d.dialServer,
 		}
+		d.connPool.Start()
 	}
 	d.enproxyConfig = d.enproxyConfigWith(func(addr string) (net.Conn, error) {
 		var conn net.Conn


### PR DESCRIPTION
This adds logic to turn connpool into a lazy connpool (i.e. it only fills up when connections are actively being requested).  This gives most of the benefit without the drawback of continually opening connections while the client is idle.
