### PR TITLE
always proxy fetching of config updates when running as client

### DIFF
--- a/src/github.com/getlantern/flashlight/config/config.go
+++ b/src/github.com/getlantern/flashlight/config/config.go
@@ -273,21 +273,28 @@ func (cfg Config) cloudPollSleepTime() time.Duration {
 	return time.Duration((CloudConfigPollInterval.Nanoseconds() / 2) + rand.Int63n(CloudConfigPollInterval.Nanoseconds()))
 }
 
-func (cfg Config) fetchCloudConfig() ([]byte, error) {
+func (cfg Config) fetchCloudConfig() (bytes []byte, err error) {
 	log.Debugf("Fetching cloud config from: %s", cfg.CloudConfig)
-	// Try it unproxied first
-	bytes, err := cfg.doFetchCloudConfig("")
-	if err != nil && cfg.IsDownstream() {
-		// If that failed, try it proxied
-		bytes, err = cfg.doFetchCloudConfig(cfg.Addr)
+
+	if cfg.IsDownstream() {
+		// Clients must always proxy the request
+		if cfg.Addr == "" {
+			err = fmt.Errorf("No proxyAddr")
+		} else {
+			bytes, err = cfg.doFetchCloudConfig(cfg.Addr)
+		}
+	} else {
+		bytes, err = cfg.doFetchCloudConfig("")
 	}
 	if err != nil {
-		return nil, fmt.Errorf("Unable to read yaml from %s: %s", cfg.CloudConfig, err)
+		bytes = nil
+		err = fmt.Errorf("Unable to read yaml from %s: %s", cfg.CloudConfig, err)
 	}
-	return bytes, err
+	return
 }
 
 func (cfg Config) doFetchCloudConfig(proxyAddr string) ([]byte, error) {
+	log.Tracef("doFetchCloudConfig via '%s'", proxyAddr)
 	client, err := util.HTTPClient(cfg.CloudConfigCA, proxyAddr)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to initialize HTTP client: %s", err)


### PR DESCRIPTION
I've tested this change in devel by running both as client and server and checking that the following gets printed only in the first case.

`balancer: Dialing tcp://s3.amazonaws.com:443 with fronted proxy at fallbacks.getiantem.org:443 using masquerade set cloudflare`

I also run with TRACE=true and grepped for doFetchCloudConfig.

I couldn't build the valencia branch in first place, apparently for reasons that have nothing to do with this change:

```
# pkg-config --cflags gtk+-3.0 appindicator3-0.1
Package gtk+-3.0 was not found in the pkg-config search path.
Perhaps you should add the directory containing `gtk+-3.0.pc'
to the PKG_CONFIG_PATH environment variable
No package 'gtk+-3.0' found
Package appindicator3-0.1 was not found in the pkg-config search path.
Perhaps you should add the directory containing `appindicator3-0.1.pc'
to the PKG_CONFIG_PATH environment variable
No package 'appindicator3-0.1' found
pkg-config: exit status 1
```
