### PR TITLE
Optimizing build a little

### DIFF
--- a/crosscompile.bash
+++ b/crosscompile.bash
@@ -7,9 +7,10 @@
 VERSION="`git describe --abbrev=0 --tags --exact-match || git rev-parse --short HEAD`"
 BUILD_DATE="`date -u +%Y%m%d%.%H%M%S`"
 LOGGLY_TOKEN="469973d5-6eaf-445a-be71-cf27141316a1"
+LDFLAGS="-w -X main.version $VERSION -X main.buildDate $BUILD_DATE -X main.logglyToken LOGGLY_TOKEN"
 echo "Building flashlight version $VERSION ($BUILD_DATE)"
 # gox -ldflags="-w -X main.version $VERSION -X main.buildDate $BUILD_DATE -X main.logglyToken LOGGLY_TOKEN" -osarch="linux/386 linux/amd64 windows/386 darwin/amd64" github.com/getlantern/flashlight
 # Compile for Mac
-CGO_ENABLED=1 gox -tags="prod" -ldflags="-w -X main.version $VERSION -X main.buildDate $BUILD_DATE -X main.logglyToken LOGGLY_TOKEN" -osarch="darwin/amd64" -output="lantern_{{.OS}}_{{.Arch}}" github.com/getlantern/flashlight
+CGO_ENABLED=1 gox -tags="prod" -ldflags="$LDFLAGS" -osarch="darwin/amd64" -output="lantern_{{.OS}}_{{.Arch}}" github.com/getlantern/flashlight
 # Compile for Windows (use -H=windowsgui ldflag to make this a Windows instead of a console app)
-CGO_ENABLED=1 gox -tags="prod" -ldflags="-w -X main.version $VERSION -X main.buildDate $BUILD_DATE -X main.logglyToken LOGGLY_TOKEN -H=windowsgui" -osarch="windows/386" -output="lantern_{{.OS}}_{{.Arch}}" github.com/getlantern/flashlight
+CGO_ENABLED=1 gox -tags="prod" -ldflags="$LDFLAGS -H=windowsgui" -osarch="windows/386" -output="lantern_{{.OS}}_{{.Arch}}" github.com/getlantern/flashlight

--- a/genassets.bash
+++ b/genassets.bash
@@ -2,14 +2,22 @@
 
 echo "Generating UI resources for embedding"
 
-echo "First, generating dist folder"
-cd src/github.com/getlantern/lantern-ui
-npm install
-rm -Rf dist
-gulp build
-cd -
+LANTERN_UI="src/github.com/getlantern/lantern-ui"
+APP="$LANTERN_UI/app"
+DIST="$LANTERN_UI/dist"
 
-echo "Now generating resources.go"
+if [ ! -d $DIST ] || [ $APP -nt $DIST ]; then
+    echo "Updating dist folder"
+    cd $LANTERN_UI
+    npm install
+    rm -Rf dist
+    gulp build
+    cd -
+else
+    echo "Dist folder is up to date"
+fi
+
+echo "Generating resources.go"
 go install github.com/getlantern/tarfs/tarfs
 dest="src/github.com/getlantern/flashlight/ui/resources.go"
 echo "// +build prod" > $dest


### PR DESCRIPTION
The way I originally set up crosscompile.bash, it's running gulp every time.  I've updated it to only run gulp if the app folder has more recent changes than what's already in dist.  This way, if we didn't touch the UI, the build proceeds a lot more quickly.  I will separately check in the dist folder so that this way, anyone who just clones the repo can build immediately without gulp needing to run.

While I was in here, I also consolidated the common linker flags into a variable.
