### PR TITLE
Display current version of lantern in the UI

### DIFF
--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -19,6 +19,7 @@ import (
 	"github.com/getlantern/flashlight/geolookup"
 	"github.com/getlantern/flashlight/proxiedsites"
 	"github.com/getlantern/flashlight/server"
+	"github.com/getlantern/flashlight/settings"
 	"github.com/getlantern/flashlight/statreporter"
 	"github.com/getlantern/flashlight/statserver"
 	"github.com/getlantern/flashlight/ui"
@@ -134,6 +135,8 @@ func runClientProxy(cfg *config.Config) {
 		}
 		ui.Show()
 	}
+
+	settings.Configure(version, buildDate)
 
 	proxiedsites.Configure(cfg.ProxiedSites)
 	if hqfd == nil {

--- a/src/github.com/getlantern/flashlight/settings/settings.go
+++ b/src/github.com/getlantern/flashlight/settings/settings.go
@@ -1,0 +1,41 @@
+// service for exchanging current user settings with UI
+package settings
+
+import (
+	"github.com/getlantern/flashlight/ui"
+	"github.com/getlantern/golog"
+)
+
+const (
+	messageType = `Settings`
+)
+
+var (
+	log     = golog.LoggerFor("flashlight.settings")
+	service *ui.Service
+)
+
+type Settings struct {
+	Version   string
+	BuildDate string
+}
+
+func Configure(version, buildDate string) {
+	// base settings are always written
+	baseSettings := &Settings{
+		Version:   version,
+		BuildDate: buildDate,
+	}
+	start(baseSettings)
+}
+
+func start(baseSettings *Settings) error {
+	var err error
+	helloFn := func(write func(interface{}) error) error {
+		log.Debugf("Sending Lantern settings to new client")
+		return write(baseSettings)
+	}
+
+	service, err = ui.Register(messageType, nil, helloFn)
+	return err
+}

--- a/src/github.com/getlantern/lantern-ui/app/_css/app.css
+++ b/src/github.com/getlantern/lantern-ui/app/_css/app.css
@@ -8040,6 +8040,10 @@ body.giveMode #npending {
   color: red;
 }
 
+#appInfo span.version {
+    color: #eeeeee;
+}
+
 @-webkit-keyframes defaultPulse {
   from {
     opacity: 1;

--- a/src/github.com/getlantern/lantern-ui/app/js/app.js
+++ b/src/github.com/getlantern/lantern-ui/app/js/app.js
@@ -157,28 +157,11 @@ var app = angular.module('app', [
         prettyUserFltr = $filter('prettyUser'),
         reportedStateFltr = $filter('reportedState');
 
-    // configure settings
-    // set default client to get-mode
-    model.settings = {};
-    model.settings.mode = 'get';
-
     // for easier inspection in the JavaScript console
     $window.rootScope = $rootScope;
     $window.model = model;
 
     $rootScope.EXTERNAL_URL = EXTERNAL_URL;
-
-    $http.get('data/package.json').
-      success(function(pkg, status, headers, config) {
-      var version = pkg.version,
-        components = version.split('.'),
-        major = components[0],
-        minor = components[1],
-        patch = (components[2] || '').split('-')[0];
-        $rootScope.lanternUiVersion = [major, minor, patch].join('.');
-    }).error(function(data, status, headers, config) {
-       console.log("Error retrieving UI version!");
-    });
 
     $rootScope.model = model;
     $rootScope.DEFAULT_AVATAR_URL = 'img/default-avatar.png';

--- a/src/github.com/getlantern/lantern-ui/app/js/services.js
+++ b/src/github.com/getlantern/lantern-ui/app/js/services.js
@@ -65,6 +65,16 @@ angular.module('app.services', [])
             model.location.resolved = true;
         }
       },
+      'Settings': function(data) {
+        console.log('Got Lantern default settings: ', data);
+        if (data && data.Version) {
+            // configure settings
+            // set default client to get-mode
+            model.settings = {};
+            model.settings.mode = 'get';
+            model.settings.version = data.Version + "(" + data.BuildDate + ")";
+        }
+      },
       'ProxiedSites': function(data) {
         if (!$rootScope.entries) {
           console.log("Initializing proxied sites entries", data.Additions);

--- a/src/github.com/getlantern/lantern-ui/app/js/services.js
+++ b/src/github.com/getlantern/lantern-ui/app/js/services.js
@@ -72,7 +72,7 @@ angular.module('app.services', [])
             // set default client to get-mode
             model.settings = {};
             model.settings.mode = 'get';
-            model.settings.version = data.Version + "(" + data.BuildDate + ")";
+            model.settings.version = data.Version + " (" + data.BuildDate + ")";
         }
       },
       'ProxiedSites': function(data) {

--- a/src/github.com/getlantern/lantern-ui/app/partials/footer.html
+++ b/src/github.com/getlantern/lantern-ui/app/partials/footer.html
@@ -27,11 +27,7 @@
 
   <div id="appInfo">
     <a ng-click="showModal('welcome')">{{ 'LANTERN' | translate }}</a>
-    {{ model.version.installed | version:true }}
-    <span ng-show="model.version.updateAvailable" class="update-available">
-      · <i class="icon-exclamation-sign"></i>
-      <a ng-click="interaction(INTERACTION.updateAvailable)">{{ 'UPDATE_AVAILABLE_TITLE' | translate }}</a>
-    </span>
+    <span class="version">{{ model.settings.version }}</span>
     <span>
       · <a ng-click="showModal('about')">{{ 'ABOUT' | translate }}</a>
     </span>


### PR DESCRIPTION
This PR includes a new service for sending Lantern's current settings to the UI. Right now, the only info being sent is the version number and build date, but we can modify this next to include user-specific settings such as whether or not Lantern should run on system start, if usage should be anonymously reported, etc.
