### PR TITLE
adjust logging level in tarfs to avoid confusing

### DIFF
--- a/src/github.com/getlantern/tarfs/tarfs.go
+++ b/src/github.com/getlantern/tarfs/tarfs.go
@@ -44,13 +44,13 @@ func New(tarData []byte, local string) (*FileSystem, error) {
 		_, err := os.Stat(local)
 		if err != nil {
 			if os.IsNotExist(err) {
-				log.Debugf("Local dir %v does not exist, not using\n", local)
+				log.Tracef("Local dir %v does not exist, not using\n", local)
 			} else {
 				log.Errorf("Unable to stat local dir %v, not using: %v\n", local, err)
 			}
 			local = ""
 		} else {
-			log.Tracef("Using local filesystem at %v", local)
+			log.Debugf("Using local filesystem at %v", local)
 		}
 	}
 


### PR DESCRIPTION
This corresponding to https://github.com/getlantern/lantern/issues/2133.

The local directory should not exists in production, but attention is required if it does exist, so I swap the logging level.