### PR TITLE
Pointing at new cloud.yaml that includes chained fallback servers

### DIFF
--- a/src/github.com/getlantern/flashlight/config/config.go
+++ b/src/github.com/getlantern/flashlight/config/config.go
@@ -208,7 +208,7 @@ func (cfg *Config) ApplyDefaults() {
 	}
 
 	if cfg.CloudConfig == "" {
-		cfg.CloudConfig = "https://s3.amazonaws.com/lantern_config/cloud.valencia.yaml.gz"
+		cfg.CloudConfig = "https://s3.amazonaws.com/lantern_config/cloud.2.0.0-beta3.yaml.gz"
 	}
 
 	// Default country


### PR DESCRIPTION
The yaml has already been uploaded.

If this is working, the vast majority of your traffic should look like it has an IP address in NY (not Singapore, not Amsterdam).
