### PR TITLE
nonStopWriter never fails 

### DIFF
--- a/src/github.com/getlantern/flashlight/logging/logging.go
+++ b/src/github.com/getlantern/flashlight/logging/logging.go
@@ -228,33 +228,11 @@ func NonStopWriter(writers ...io.Writer) io.Writer {
 	return &nonStopWriter{w}
 }
 
-// Write implements the method from io.Writer. It returns the smallest number
-// of bytes written to any of the writers and the first error encountered in
-// writing to any of the writers.
+// Write implements the method from io.Writer.
+// It never fails and always return the length of bytes passed in
 func (t *nonStopWriter) Write(p []byte) (int, error) {
-	var fn int
-	var ferr error
-	first := true
 	for _, w := range t.writers {
-		n, err := w.Write(p)
-		if first {
-			fn, ferr = n, err
-			first = false
-		} else {
-			// Use the smallest written n
-			if n < fn {
-				fn = n
-			}
-			// Use the first error encountered
-			if ferr == nil && err != nil {
-				ferr = err
-			}
-		}
+		w.Write(p)
 	}
-
-	if ferr == nil && fn < len(p) {
-		ferr = io.ErrShortWrite
-	}
-
-	return fn, ferr
+	return len(p), nil
 }


### PR DESCRIPTION
Resolves getlantern/lantern#2354

Writing to stdout and stderr will fail if `-Hwindowsgui` supplied, `timestamped` wil stop to write log message if it sees any error while writing timestamp. this PR correct it.