### PR TITLE
Add headless build option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ define build-tags
 		sed s/'packageVersion.*'/'packageVersion = "'$$VERSION'"'/ src/github.com/getlantern/flashlight/autoupdate.go | sed s/'!prod'/'prod'/ > src/github.com/getlantern/flashlight/autoupdate-prod.go; \
 	else \
 		echo "** VERSION was not set, using git revision instead ($(GIT_REVISION)). This is OK while in development."; \
+	fi && \
+	if [[ -z "$$HEADLESS" ]]; then \
+		BUILD_TAGS="$$BUILD_TAGS headless"; \
 	fi
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,9 @@ define build-tags
 	fi && \
 	if [[ ! -z "$$HEADLESS" ]]; then \
 		BUILD_TAGS="$$BUILD_TAGS headless"; \
-	fi
+	fi && \
+	BUILD_TAGS=$$(echo $$BUILD_TAGS | xargs) && \
+	echo "Build tags: $$BUILD_TAGS"
 endef
 
 define docker-up
@@ -172,21 +174,21 @@ genassets:
 linux-amd64:
 	@echo "Building linux/amd64..." && \
 	$(call docker-up) && \
-	docker run -v $$PWD:/flashlight-build -t $(DOCKER_IMAGE_TAG) /bin/bash -c 'cd /flashlight-build && VERSION="'$$VERSION'" U_UID="'$$UID'" U_GID="'$$GID'" make docker-linux-amd64' && \
+	docker run -v $$PWD:/flashlight-build -t $(DOCKER_IMAGE_TAG) /bin/bash -c 'cd /flashlight-build && VERSION="'$$VERSION'" HEADLESS="'$$HEADLESS'" make docker-linux-amd64' && \
 	cat lantern_linux_amd64 | bzip2 > update_linux_amd64.bz2 && \
 	ls -l lantern_linux_amd64 update_linux_amd64.bz2
 
 linux-386:
 	@echo "Building linux/386..." && \
 	$(call docker-up) && \
-	docker run -v $$PWD:/flashlight-build -t $(DOCKER_IMAGE_TAG) /bin/bash -c 'cd /flashlight-build && VERSION="'$$VERSION'" make docker-linux-386' && \
+	docker run -v $$PWD:/flashlight-build -t $(DOCKER_IMAGE_TAG) /bin/bash -c 'cd /flashlight-build && VERSION="'$$VERSION'" HEADLESS="'$$HEADLESS$'" make docker-linux-386' && \
 	cat lantern_linux_386 | bzip2 > update_linux_386.bz2 && \
 	ls -l lantern_linux_386 update_linux_386.bz2
 
 windows-386:
 	@echo "Building windows/386..." && \
 	$(call docker-up) && \
-	docker run -v $$PWD:/flashlight-build -t $(DOCKER_IMAGE_TAG) /bin/bash -c 'cd /flashlight-build && VERSION="'$$VERSION'" make docker-windows-386' && \
+	docker run -v $$PWD:/flashlight-build -t $(DOCKER_IMAGE_TAG) /bin/bash -c 'cd /flashlight-build && VERSION="'$$VERSION'" HEADLESS="'$$HEADLESS'" make docker-windows-386' && \
 	cat lantern_windows_386.exe | bzip2 > update_windows_386.bz2 && \
 	ls -l lantern_windows_386.exe update_windows_386.bz2
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ define build-tags
 	else \
 		echo "** VERSION was not set, using git revision instead ($(GIT_REVISION)). This is OK while in development."; \
 	fi && \
-	if [[ -z "$$HEADLESS" ]]; then \
+	if [[ ! -z "$$HEADLESS" ]]; then \
 		BUILD_TAGS="$$BUILD_TAGS headless"; \
 	fi
 endef

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ shortcut:
 make binaries
 ```
 
+### Building headless version
+
+If `HEADLESS` environment variable is set, the generated binaries will be
+headless, that is, it doesn't depend on the systray support libraries, and
+will not show systray or UI.
+
 ## Packaging
 
 Packaging requires some special environemnt variables.

--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -14,7 +14,6 @@ import (
 	"github.com/getlantern/golog"
 	"github.com/getlantern/i18n"
 	"github.com/getlantern/profiling"
-	"github.com/getlantern/systray"
 
 	"github.com/getlantern/flashlight/analytics"
 	"github.com/getlantern/flashlight/autoupdate"
@@ -74,7 +73,7 @@ func main() {
 	showui = !*headless
 
 	if showui {
-		systray.Run(_main)
+		runOnSystrayReady(_main)
 	} else {
 		log.Debug("Running headless")
 		_main()
@@ -99,7 +98,7 @@ func doMain() error {
 	// Schedule cleanup actions
 	defer logging.Close()
 	defer pacOff()
-	defer systray.Quit()
+	defer quitSystray()
 
 	i18nInit()
 	if showui {
@@ -303,30 +302,6 @@ func useAllCores() {
 	numcores := runtime.NumCPU()
 	log.Debugf("Using all %d cores on machine", numcores)
 	runtime.GOMAXPROCS(numcores)
-}
-
-func configureSystemTray() error {
-	icon, err := Asset("icons/16on.ico")
-	if err != nil {
-		return fmt.Errorf("Unable to load icon for system tray: %v", err)
-	}
-	systray.SetIcon(icon)
-	systray.SetTooltip("Lantern")
-	show := systray.AddMenuItem(i18n.T("TRAY_SHOW_LANTERN"), i18n.T("SHOW"))
-	quit := systray.AddMenuItem(i18n.T("TRAY_QUIT"), i18n.T("QUIT"))
-	go func() {
-		for {
-			select {
-			case <-show.ClickedCh:
-				ui.Show()
-			case <-quit.ClickedCh:
-				exit(nil)
-				return
-			}
-		}
-	}()
-
-	return nil
 }
 
 // exit tells the application to exit, optionally supplying an error that caused

--- a/src/github.com/getlantern/flashlight/null_systray.go
+++ b/src/github.com/getlantern/flashlight/null_systray.go
@@ -1,0 +1,15 @@
+// +build headless
+
+package main
+
+func runOnSystrayReady(f func()) {
+	showui = false
+	f()
+}
+
+func quitSystray() {
+}
+
+func configureSystemTray() error {
+	return nil
+}

--- a/src/github.com/getlantern/flashlight/systray.go
+++ b/src/github.com/getlantern/flashlight/systray.go
@@ -1,0 +1,42 @@
+// +build !headless
+
+package main
+
+import (
+	"fmt"
+	"github.com/getlantern/i18n"
+	"github.com/getlantern/systray"
+
+	"github.com/getlantern/flashlight/ui"
+)
+
+func runOnSystrayReady(f func()) {
+	systray.Run(f)
+}
+
+func quitSystray() {
+	systray.Quit()
+}
+func configureSystemTray() error {
+	icon, err := Asset("icons/16on.ico")
+	if err != nil {
+		return fmt.Errorf("Unable to load icon for system tray: %v", err)
+	}
+	systray.SetIcon(icon)
+	systray.SetTooltip("Lantern")
+	show := systray.AddMenuItem(i18n.T("TRAY_SHOW_LANTERN"), i18n.T("SHOW"))
+	quit := systray.AddMenuItem(i18n.T("TRAY_QUIT"), i18n.T("QUIT"))
+	go func() {
+		for {
+			select {
+			case <-show.ClickedCh:
+				ui.Show()
+			case <-quit.ClickedCh:
+				exit(nil)
+				return
+			}
+		}
+	}()
+
+	return nil
+}


### PR DESCRIPTION
set `HEADLESS_BUILD=true` before running 'crosscompile.bash' and 'linuxcompile.bash', so it can be built and run at platforms not have systray support libraries.

Resolves https://github.com/getlantern/lantern/issues/2347