### PR TITLE
Providing support for bzip2 compressed assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bin
 *.swp
 *.deb
 *.swo
+update_*.bz2
 flashlight_darwin_amd64
 flashlight_linux_386
 flashlight_linux_amd64

--- a/src/github.com/getlantern/autoupdate-server/Makefile
+++ b/src/github.com/getlantern/autoupdate-server/Makefile
@@ -1,0 +1,5 @@
+all:
+	GOOS=linux GOARCH=amd64 go build -o autoupdate-server
+
+clean:
+	rm -f autoupdate-server

--- a/src/github.com/getlantern/autoupdate-server/server/asset.go
+++ b/src/github.com/getlantern/autoupdate-server/server/asset.go
@@ -49,9 +49,7 @@ func downloadAsset(uri string) (localfile string, err error) {
 			return "", fmt.Errorf("Expecting 200 OK, got: %s", res.Status)
 		}
 
-		if res.Body != nil {
-			defer res.Body.Close()
-		}
+		defer res.Body.Close()
 
 		var fp *os.File
 

--- a/src/github.com/getlantern/autoupdate-server/server/asset.go
+++ b/src/github.com/getlantern/autoupdate-server/server/asset.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"compress/bzip2"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -24,6 +25,7 @@ func init() {
 // then into $ASSETS_DIRECTORY/$BASENAME.SHA256_SUM($URL)
 func downloadAsset(uri string) (localfile string, err error) {
 	basename := path.Base(uri)
+	fileExt := path.Ext(basename)
 
 	// We'll be appending 65 chars to create a local file name for the asset,
 	// this 60-char limit prevents creating a file name longer than 255 chars. We
@@ -36,6 +38,7 @@ func downloadAsset(uri string) (localfile string, err error) {
 	localfile = assetsDirectory + fmt.Sprintf("%s.%x", basename, sha256.Sum256([]byte(uri)))
 
 	if !fileExists(localfile) {
+		var body io.Reader
 		var res *http.Response
 
 		if res, err = http.Get(uri); err != nil {
@@ -46,6 +49,10 @@ func downloadAsset(uri string) (localfile string, err error) {
 			return "", fmt.Errorf("Expecting 200 OK, got: %s", res.Status)
 		}
 
+		if res.Body != nil {
+			defer res.Body.Close()
+		}
+
 		var fp *os.File
 
 		if fp, err = os.Create(localfile); err != nil {
@@ -54,7 +61,13 @@ func downloadAsset(uri string) (localfile string, err error) {
 
 		defer fp.Close()
 
-		if _, err = io.Copy(fp, res.Body); err != nil {
+		if fileExt == ".bz2" {
+			body = bzip2.NewReader(res.Body)
+		} else {
+			body = res.Body
+		}
+
+		if _, err = io.Copy(fp, body); err != nil {
 			return "", err
 		}
 

--- a/src/github.com/getlantern/autoupdate-server/server/asset_test.go
+++ b/src/github.com/getlantern/autoupdate-server/server/asset_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	testAssetURL = `https://github.com/getlantern/autoupdate-server/releases/download/0.4.0/autoupdate-binary-darwin-amd64.v4`
+	testAssetURL = `https://github.com/getlantern/autoupdate/releases/download/2.0.0-beta3/update_darwin_amd64`
 )
 
 func TestDownloadAsset(t *testing.T) {

--- a/src/github.com/getlantern/autoupdate-server/server/github.go
+++ b/src/github.com/getlantern/autoupdate-server/server/github.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	updateAssetRe = regexp.MustCompile(`^autoupdate-binary-(darwin|windows|linux)-(arm|386|amd64)\.?.*$`)
+	updateAssetRe = regexp.MustCompile(`^update_(darwin|windows|linux)_(arm|386|amd64)\.?.*$`)
 
 	emptyVersion semver.Version
 )

--- a/src/github.com/getlantern/autoupdate-server/server/github_test.go
+++ b/src/github.com/getlantern/autoupdate-server/server/github_test.go
@@ -12,41 +12,41 @@ func TestSplitUpdateAsset(t *testing.T) {
 	var err error
 	var info *AssetInfo
 
-	if info, err = getAssetInfo("autoupdate-binary-darwin-386.dmg"); err != nil {
+	if info, err = getAssetInfo("update_darwin_386.dmg"); err != nil {
 		t.Fatal(fmt.Errorf("Failed to get asset info: %q", err))
 	}
 	if info.OS != OS.Darwin || info.Arch != Arch.X86 {
 		t.Fatal("Failed to identify update asset.")
 	}
 
-	if info, err = getAssetInfo("autoupdate-binary-darwin-amd64.v1"); err != nil {
+	if info, err = getAssetInfo("update_darwin_amd64.v1"); err != nil {
 		t.Fatal(fmt.Errorf("Failed to get asset info: %q", err))
 	}
 	if info.OS != OS.Darwin || info.Arch != Arch.X64 {
 		t.Fatal("Failed to identify update asset.")
 	}
 
-	if info, err = getAssetInfo("autoupdate-binary-linux-arm"); err != nil {
+	if info, err = getAssetInfo("update_linux_arm"); err != nil {
 		t.Fatal(fmt.Errorf("Failed to get asset info: %q", err))
 	}
 	if info.OS != OS.Linux || info.Arch != Arch.ARM {
 		t.Fatal("Failed to identify update asset.")
 	}
 
-	if info, err = getAssetInfo("autoupdate-binary-windows-386"); err != nil {
+	if info, err = getAssetInfo("update_windows_386"); err != nil {
 		t.Fatal(fmt.Errorf("Failed to get asset info: %q", err))
 	}
 	if info.OS != OS.Windows || info.Arch != Arch.X86 {
 		t.Fatal("Failed to identify update asset.")
 	}
 
-	if _, err = getAssetInfo("autoupdate-binary-osx-386"); err == nil {
+	if _, err = getAssetInfo("update_osx_386"); err == nil {
 		t.Fatalf("Should have ignored the release, \"osx\" is not a valid OS value.")
 	}
 }
 
 func TestNewClient(t *testing.T) {
-	testClient = NewReleaseManager("getlantern", "autoupdate-server")
+	testClient = NewReleaseManager("getlantern", "autoupdate")
 	if testClient == nil {
 		t.Fatal("Failed to create new client.")
 	}


### PR DESCRIPTION
This PR provides support for reading bzip2 compressed assets on the update server. The Makefile was also modified in order to generate such assets.
