### PR TITLE
fix nil pointer in server mode

### DIFF
--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -275,7 +275,7 @@ func runServerProxy(cfg *config.Config) {
 	}
 
 	srv.Configure(cfg.Server)
-	analytics.Configure(nil, true, nil)
+	analytics.Configure(cfg, true, nil)
 
 	// Continually poll for config updates and update server accordingly
 	go func() {


### PR DESCRIPTION
I'm not sure if analytics should be configured at all in server mode, but pass a `nil` will cause a panic in [analytics](https://github.com/getlantern/flashlight-build/blob/valencia/src/github.com/getlantern/flashlight/analytics/analytics.go#L31)

Fixes https://github.com/getlantern/lantern/issues/2364.