### PR TITLE
Check subdomains in detour whitelist

### DIFF
--- a/src/github.com/getlantern/detour/detour_test.go
+++ b/src/github.com/getlantern/detour/detour_test.go
@@ -54,7 +54,7 @@ func TestBlockedImmediately(t *testing.T) {
 	}
 
 	client = newClient(proxiedURL, 100*time.Millisecond)
-	removeFromWl(u.Host)
+	RemoveFromWl(u.Host)
 	resp, err = client.PostForm(mockURL, url.Values{"key": []string{"value"}})
 	if assert.Error(t, err, "Non-idempotent method should not be detoured in same connection") {
 		assert.True(t, wlTemporarily(u.Host), "but should be added to whitelist so will detour next time")
@@ -93,7 +93,7 @@ func TestRemoveFromWhitelist(t *testing.T) {
 	client := newClient(proxiedURL, 100*time.Millisecond)
 
 	u, _ := url.Parse(mockURL)
-	addToWl(u.Host, false)
+	AddToWl(u.Host, false)
 	_, err := client.Get(mockURL)
 	if assert.Error(t, err, "should have error if reading times out through detour") {
 		assert.False(t, whitelisted(u.Host), "should be removed from whitelist if reading times out through detour")

--- a/src/github.com/getlantern/detour/whitelist.go
+++ b/src/github.com/getlantern/detour/whitelist.go
@@ -14,16 +14,18 @@ var (
 	whitelist   = make(map[string]wlEntry)
 )
 
-// InitWhitelist adds a list of domains to whitelist,
-// all subdomains of the listed domains are also
-// considered to be in the whitelist.
-func InitWhitelist(wl []string) {
+// AddToWl adds a domain to whitelist, all subdomains of this domain
+// are also considered to be in the whitelist.
+func AddToWl(addr string, permanent bool) {
 	muWhitelist.Lock()
 	defer muWhitelist.Unlock()
-	for _, v := range wl {
-		whitelist[v] = wlEntry{true}
-	}
-	return
+	whitelist[addr] = wlEntry{permanent}
+}
+
+func RemoveFromWl(addr string) {
+	muWhitelist.Lock()
+	defer muWhitelist.Unlock()
+	delete(whitelist, addr)
 }
 
 func DumpWhitelist() (wl []string) {
@@ -56,18 +58,6 @@ func wlTemporarily(addr string) bool {
 	// temporary domains are always full ones, just check map
 	p, ok := whitelist[addr]
 	return ok && p.permanent == false
-}
-
-func addToWl(addr string, permanent bool) {
-	muWhitelist.Lock()
-	defer muWhitelist.Unlock()
-	whitelist[addr] = wlEntry{permanent}
-}
-
-func removeFromWl(addr string) {
-	muWhitelist.Lock()
-	defer muWhitelist.Unlock()
-	delete(whitelist, addr)
 }
 
 func getParentDomain(addr string) string {

--- a/src/github.com/getlantern/detour/whitelist_test.go
+++ b/src/github.com/getlantern/detour/whitelist_test.go
@@ -6,19 +6,14 @@ import (
 	"github.com/getlantern/testify/assert"
 )
 
-var ()
-
 func TestCheckSubdomain(t *testing.T) {
-	wl := []string{
-		"facebook.com:80",
-	}
-	InitWhitelist(wl)
+	AddToWl("facebook.com:80", true)
 	assert.True(t, whitelisted("www.facebook.com:80"), "should match subdomain")
 }
 
 func TestDumpWhiteList(t *testing.T) {
-	addToWl("a.com:80", true)
-	addToWl("b.com:80", false)
+	AddToWl("a.com:80", true)
+	AddToWl("b.com:80", false)
 	dumped := DumpWhitelist()
 	assert.Contains(t, dumped, "a.com:80", "dumped list should contain permanent items")
 	assert.NotContains(t, dumped, "b.com:80", "dumped list should not contain temporary items")

--- a/src/github.com/getlantern/detour/whitelist_test.go
+++ b/src/github.com/getlantern/detour/whitelist_test.go
@@ -9,6 +9,7 @@ import (
 func TestCheckSubdomain(t *testing.T) {
 	AddToWl("facebook.com:80", true)
 	assert.True(t, whitelisted("www.facebook.com:80"), "should match subdomain")
+	assert.True(t, whitelisted("sub2.facebook.com:80"), "should match all subdomains")
 }
 
 func TestDumpWhiteList(t *testing.T) {

--- a/src/github.com/getlantern/detour/whitelist_test.go
+++ b/src/github.com/getlantern/detour/whitelist_test.go
@@ -1,0 +1,25 @@
+package detour
+
+import (
+	"testing"
+
+	"github.com/getlantern/testify/assert"
+)
+
+var ()
+
+func TestCheckSubdomain(t *testing.T) {
+	wl := []string{
+		"facebook.com:80",
+	}
+	InitWhitelist(wl)
+	assert.True(t, whitelisted("www.facebook.com:80"), "should match subdomain")
+}
+
+func TestDumpWhiteList(t *testing.T) {
+	addToWl("a.com:80", true)
+	addToWl("b.com:80", false)
+	dumped := DumpWhitelist()
+	assert.Contains(t, dumped, "a.com:80", "dumped list should contain permanent items")
+	assert.NotContains(t, dumped, "b.com:80", "dumped list should not contain temporary items")
+}

--- a/src/github.com/getlantern/flashlight/proxiedsites/proxiedsites.go
+++ b/src/github.com/getlantern/flashlight/proxiedsites/proxiedsites.go
@@ -64,14 +64,13 @@ func updateDetour(delta *proxiedsites.Delta) {
 	// for simplicity, detour matches whitelist using host:port string
 	// so we add ports to each proxiedsites
 	for _, v := range delta.Deletions {
-		delete(curWl, v+":80")
-		delete(curWl, v+":443")
+		detour.RemoveFromWl(v + ":80")
+		detour.RemoveFromWl(v + ":443")
 	}
 	for _, v := range delta.Additions {
-		curWl[v+":80"] = time.Now()
-		curWl[v+":443"] = time.Now()
+		detour.AddToWl(v + ":80")
+		detour.AddToWl(v + ":443")
 	}
-	detour.InitWhitelist(curWl)
 }
 
 func start() (err error) {

--- a/src/github.com/getlantern/flashlight/proxiedsites/proxiedsites.go
+++ b/src/github.com/getlantern/flashlight/proxiedsites/proxiedsites.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/getlantern/detour"
 	"github.com/getlantern/golog"
@@ -60,7 +59,7 @@ func updateDetour(delta *proxiedsites.Delta) {
 	// TODO: subscribe changes of geolookup and set country accordingly
 	// safe to hardcode here as IR has all detection rules
 	detour.SetCountry("IR")
-	curWl := detour.DumpWhitelist()
+
 	// for simplicity, detour matches whitelist using host:port string
 	// so we add ports to each proxiedsites
 	for _, v := range delta.Deletions {
@@ -68,8 +67,8 @@ func updateDetour(delta *proxiedsites.Delta) {
 		detour.RemoveFromWl(v + ":443")
 	}
 	for _, v := range delta.Additions {
-		detour.AddToWl(v + ":80")
-		detour.AddToWl(v + ":443")
+		detour.AddToWl(v+":80", true)
+		detour.AddToWl(v+":443", true)
 	}
 }
 


### PR DESCRIPTION
Our baked whitelist contains only primary domains, should check recursively to see if a site is in whitelist.

Resolves https://github.com/getlantern/lantern/issues/2371.