### PR TITLE
Using a lower-cased lantern config directory on Linux.

### DIFF
--- a/src/github.com/getlantern/flashlight/config/config.go
+++ b/src/github.com/getlantern/flashlight/config/config.go
@@ -163,16 +163,6 @@ func InConfigDir(filename string) (string, error) {
 			// in all lowercase. The lantern wrapper also expects a lowercased
 			// directory.
 			cdir = appdir.General("lantern")
-
-			// Backwards compatibility fix.
-			oldDir := appdir.General("Lantern")
-
-			if _, err := os.Stat(oldDir); err == nil {
-				// If the old configuration path exists, try to rename it. We don't
-				// need to catch the error, if something fails then we'll start a new
-				// config directory.
-				os.Rename(oldDir, cdir)
-			}
 		} else {
 			// In OSX and Windows, they prefer to see the first letter in uppercase.
 			cdir = appdir.General("Lantern")


### PR DESCRIPTION
I realized the "Lantern" name with the first character in uppercase looks fine on OSX: `/Users/rev/Library/Application\ Support/Lantern` and other apps that are in `/Users/rev/Library/Application\ Support/` follow the same convention. I just added a case for Linux, in which having cases looks and feels odd.
