### PR TITLE
Fixing compilation problem with default resources file. (Issue #2388)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,5 +345,5 @@ clean:
 	rm -f *.deb && \
 	rm -f *.png && \
 	rm -rf *.app && \
-	rm -f ./src/github.com/getlantern/flashlight/ui/resources.go && \
+	git checkout ./src/github.com/getlantern/flashlight/ui/resources.go && \
 	rm -f *.dmg

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,7 @@ genassets:
 	@echo "Generating assets..." && \
 	$(call docker-up) && \
 	docker run -v $$PWD:/flashlight-build -t $(DOCKER_IMAGE_TAG) /bin/bash -c 'cd /flashlight-build && make docker-genassets' && \
+	git update-index --assume-unchanged src/github.com/getlantern/flashlight/ui/resources.go && \
 	echo "OK"
 
 linux-amd64: require-assets

--- a/src/github.com/getlantern/flashlight/ui/resources.go
+++ b/src/github.com/getlantern/flashlight/ui/resources.go
@@ -1,0 +1,7 @@
+// This file will be overwritten by make genassets.
+
+// +build !stub
+
+package ui
+
+var Resources = []byte{}


### PR DESCRIPTION
The problem was we weren't able to build Lantern without make genassets. This should close https://github.com/getlantern/lantern/issues/2388.
