### PR TITLE
Add filename and line number to log messages

### DIFF
--- a/src/github.com/getlantern/flashlight/logging/logging_test.go
+++ b/src/github.com/getlantern/flashlight/logging/logging_test.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"bytes"
 	"encoding/json"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -23,21 +24,21 @@ func TestLoggly(t *testing.T) {
 	log.Error("")
 	if assert.NoError(t, json.Unmarshal(buf.Bytes(), &result), "Unmarshal error") {
 		assert.Equal(t, "test", result["locationInfo"])
-		assert.Equal(t, "", result["message"], "empty message should be logged as is")
+		assert.Regexp(t, regexp.MustCompile("logging_test.go:([0-9]+)"), result["message"])
 	}
 
 	buf.Reset()
 	log.Error("short message")
 	if assert.NoError(t, json.Unmarshal(buf.Bytes(), &result), "Unmarshal error") {
 		assert.Equal(t, "test", result["locationInfo"])
-		assert.Equal(t, "short message", result["message"], "short message should be logged as is")
+		assert.Regexp(t, regexp.MustCompile("logging_test.go:([0-9]+) short message"), result["message"])
 	}
 
 	buf.Reset()
 	log.Error("message with: reason")
 	if assert.NoError(t, json.Unmarshal(buf.Bytes(), &result), "Unmarshal error") {
 		assert.Equal(t, "test", result["locationInfo"])
-		assert.Equal(t, "message with: reason", result["message"], "message should be last 2 chunks")
+		assert.Regexp(t, "logging_test.go:([0-9]+) message with: reason", result["message"])
 	}
 
 	buf.Reset()
@@ -65,6 +66,6 @@ func TestLoggly(t *testing.T) {
 	log.Error(longMsg)
 	if assert.NoError(t, json.Unmarshal(buf.Bytes(), &result), "Unmarshal error") {
 		assert.Equal(t, "test", result["locationInfo"])
-		assert.Equal(t, longMsg, result["message"], "should not truncate long messages as it's unlikely to happen")
+		assert.Regexp(t, regexp.MustCompile("logging_test.go:([0-9]+) "+longMsg), result["message"])
 	}
 }

--- a/src/github.com/getlantern/golog/golog.go
+++ b/src/github.com/getlantern/golog/golog.go
@@ -121,7 +121,7 @@ func (l *logger) linePrefix() string {
 	runtime.Callers(3, l.pc)
 	funcForPc := runtime.FuncForPC(l.pc[0])
 	file, line := funcForPc.FileLine(l.pc[0])
-	return fmt.Sprintf("%s%s:%d ", l.prefix, filepath.Base(file), line-1)
+	return fmt.Sprintf("%s%s:%d ", l.prefix, filepath.Base(file), line)
 }
 
 func (l *logger) Debug(arg interface{}) {


### PR DESCRIPTION
Should be really useful. Looks like this: 

```
Apr 18 15:27:47.000 - flashlight: pac.go:110 Setting lantern as system proxy
Apr 18 15:27:47.000 - flashlight: pac.go:120 Serving PAC file at http://127.0.0.1:16785/proxy_on.pac
Apr 18 15:27:47.008 - flashlight.autoupdate: autoupdate.go:80 Software version: 9999.99.99
Apr 18 15:27:47.008 - autoupdate: autoupdate.go:58 Defaulted CheckInterval to 4h0m0s
```
